### PR TITLE
Harden Security Group rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,9 +40,27 @@ module openvpn-server {
   allow_ssh_from       = var.allow_ssh_from
   security_group_rules = concat(var.security_group_rules, [
     {
-      name      = "everything"
+      name      = "http"
       direction = "outbound"
       remote    = "0.0.0.0/0"
+      TCP = {
+        port_min = 80
+        port_max = 80
+      }
+    },
+    {
+      name      = "https"
+      direction = "outbound"
+      remote    = "0.0.0.0/0"
+      TCP = {
+        port_min = 443
+        port_max = 443
+      }
+    },
+    {
+      name      = "private-network"
+      direction = "outbound"
+      remote    = "10.0.0.0/0"
     },
     {
       name      = "openvpn"


### PR DESCRIPTION
* Updates security groups to replace wide open rule (e.g. 0.0.0.0/0 on all ports) with rules that target particular ports or particular subnets

Co-authored-by: Sean Sundberg <seansund@us.ibm.com>