### PR TITLE
Updates module metadata

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ data ibm_is_vpc vpc {
 }
 
 module "openvpn-server" {
-  source = "github.com/cloud-native-toolkit/terraform-vsi-bastion.git?ref=v1.3.3"
+  source = "github.com/cloud-native-toolkit/terraform-vsi-bastion.git?ref=v1.3.6"
 
   resource_group_id    = var.resource_group_id
   region               = var.region

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,7 @@ variable "allow_ssh_from" {
 }
 
 variable "security_group_rules" {
+  type = list(object({}))
 //  type = list(object({
 //    name=string,
 //    direction=string,

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "ssh_private_key" {
 
 variable "image_name" {
   type        = string
-  default     = "ibm-centos-7-9-minimal-amd64-2"
+  default     = "ibm-centos-7-9-minimal-amd64-3"
   description = "Name of the image to use for the OpenVPN instance"
 }
 


### PR DESCRIPTION
- Bumps vsi-bastion module to v1.3.6
- Sets the type for the security_group_rules to list(object())

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>