### PR TITLE
Adds base_security_group variable definition to metadata

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -43,6 +43,10 @@ versions:
       moduleRef:
         id: vpc
         output: name
+    - name: base_security_group
+      moduleRef:
+        id: vpc
+        output: base_security_group
     - name: subnet_count
       moduleRef:
         id: subnets


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>