### PR TITLE
Updates networking for OpenShift private endpoints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,11 @@ module "openvpn-server" {
         port_min = 22
         port_max = 22
       }
+    },
+    {
+      name      = "outbound-roks-private"
+      direction = "outbound"
+      remote    = "166.8.0.0/14"
     }
   ])
   base_security_group  = var.base_security_group

--- a/scripts/openvpn-config.sh
+++ b/scripts/openvpn-config.sh
@@ -173,6 +173,7 @@ private-address: fd42:42:42:42::/112
 private-address: 172.16.0.0/12
 private-address: 192.168.0.0/16
 private-address: 169.254.0.0/16
+private-address: 166.8.0.0/14
 private-address: fd00::/8
 private-address: fe80::/10
 private-address: 127.0.0.0/8
@@ -194,6 +195,7 @@ private-address: fd42:42:42:42::/112
 private-address: 172.16.0.0/12
 private-address: 192.168.0.0/16
 private-address: 169.254.0.0/16
+private-address: 166.8.0.0/14
 private-address: fd00::/8
 private-address: fe80::/10
 private-address: 127.0.0.0/8


### PR DESCRIPTION
- Adds 166.8.0.0/14 to private addresses in OpenVPN route configurtion
- Adds security group rule to allow outbound traffic to 166.8.0.0/14 from the VSI

Fixes #26

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>