### PR TITLE
Adds rules to network acl for the subnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,11 +82,23 @@ resource null_resource print-float_ip {
   }
 }
 
+data ibm_is_subnet subnet {
+  count = var.subnet_count > 0 ? 1 : 0
+
+  identifier = var.subnets[0].id
+}
+
+resource null_resource open_acl_rules {
+  count = var.subnet_count > 0 ? 1 : 0
+
+  provisioner "local-exec" {
+    command = "${path.module}/scripts/open-acl-rules.sh ${data.ibm_is_subnet.subnet[0].network_acl}"
+  }
+}
 
 resource null_resource setup_openvpn {
-
   count = var.subnet_count
-  depends_on = [module.openvpn-server, null_resource.print_ips, null_resource.print-float_ip]
+  depends_on = [module.openvpn-server, null_resource.print_ips, null_resource.print-float_ip, null_resource.open_acl_rules]
 
   connection {
     type        = "ssh"

--- a/scripts/open-acl-rules.sh
+++ b/scripts/open-acl-rules.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+NETWORK_ACL="$1"
+
+## TODO more sophisiticated logic needed to 1) test for existing rules and 2) place this rule in the right order
+
+ibmcloud is network-acl-rule-add "${NETWORK_ACL}" allow inbound tpc "0.0.0.0/0" "0.0.0.0/0" --name allow-ssh-ingress --source-port-min 22 --source-port-max 22 --destination-port-min 22 --destination-port-max 22
+ibmcloud is network-acl-rule-add "${NETWORK_ACL}" allow inbound udp "0.0.0.0/0" "0.0.0.0/0" --name allow-vpn-ingress --source-port-min 1194 --source-port-max 1194 --destination-port-min 1194 --destination-port-max 1194


### PR DESCRIPTION
- Allow inbound traffic from internet for ssh (tcp/22)
- Allow inbound traffic from internet for vpn (udp/1194)
- Assumes required access to internal resources have already been configured
- External access to the internet should not be required

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>